### PR TITLE
docs: add app documentation and dataset source notes

### DIFF
--- a/Code_Explanation.md
+++ b/Code_Explanation.md
@@ -1,0 +1,259 @@
+# Code Analysis for the `gbif_app_v2` Application
+
+## Table of Contents
+1. [1. Overview](#sec-1)
+2. [2. Step-by-Step Breakdown](#sec-2)
+3. [3. Key Concepts](#sec-3)
+4. [4. Potential Issues](#sec-4)
+5. [5. Usage Example](#sec-5)
+6. [6. Operational Issue on shinyapps.io](#sec-6)
+
+<a id="sec-1"></a>
+## 1. Overview
+This is a Shiny application for working with GBIF data. A user defines an area of interest, either by selecting an administrative unit, uploading a boundary, or drawing a polygon, optionally creates a buffer around it, retrieves a spatial subset of occurrence records, and filters the results by biodiversity conservation criteria.
+
+The application then displays the results on maps and in tables, and generates CSV/XLSX exports and HTML/DOCX reports.
+
+<a id="sec-2"></a>
+## 2. Step-by-Step Breakdown
+
+### 2.1. Files and Module Roles
+- `app.R` - the main UI and server file, containing the core reactivity, map, filter, and report logic.
+- `config.R` - constants and reference data: column lists, filters, colors, and buffer parameters.
+- `custom_functions.R` - geospatial helper functions:
+  - `polygon_bufferisation()` - buffers a polygon in a metric CRS and converts it back to WGS84.
+  - `leaf_draw_sf_polyg()` - converts Leaflet Draw coordinates into an `sf` geometry.
+- `global_reactive_value.R` - global `reactiveVal()` values for the AOI, buffer, report tables, and counters.
+- `localization_ua.R` / `localization_en.R` - UI and report text strings for localization.
+- `templates/report.Rmd` - the final report template.
+
+### 2.2. Initialization (`app.R`, lines ~1-90)
+- The code clears the environment with `rm(list = ls())` and runs `gc()`.
+- Libraries are loaded: `shiny`, `sf`, `leaflet`, `dplyr`, `DT`, `rmarkdown`, and others.
+- Configuration, reactive values, functions, and localization are sourced. Ukrainian is used by default.
+- The application reads:
+  - dataset metadata (`metadata.Rdata`) for the DOI and date;
+  - administrative layers `adm_1/2/3.shp`.
+- The OTG list is prepared for `pickerInput`.
+
+Why it is structured this way:
+- Splitting logic into `source(...)` files keeps `app.R` relatively readable.
+- Keeping configuration, functions, and UI/server logic separate is a reasonable baseline modular style for Shiny.
+
+### 2.3. UI Layer (`app.R`, lines ~94-339)
+The interface is built with a `tabsetPanel` containing five tabs:
+1. Map and territory selection.
+2. Filtering and a map of filtered points.
+3. Table preview and CSV/XLSX export.
+4. Reports, summary tables, and HTML/DOCX generation.
+5. About.
+
+Additional details:
+- A loading spinner is implemented through `conditionalPanel` and CSS when `shiny-busy` is active.
+- All labels are taken from the localization file instead of being hard-coded in the UI.
+
+Shiny idiom:
+- This follows the classic "thin UI + heavy server" pattern: the UI describes structure, while the logic lives in the server.
+
+### 2.4. Creating Maps and the Drawing Tool (`app.R`, lines ~345-413)
+- Two maps are created:
+  - `map` - the main AOI map;
+  - `map2` - the map shown after filtering.
+- Base layers include Visicom and ESRI imagery.
+- `addDrawToolbar` is attached to `map` for drawing, editing, and deleting polygons.
+- Updates use `leafletProxy` so the whole map does not need to be rebuilt.
+
+Why this matters:
+- `leafletProxy` reduces load and avoids visible full map redraws.
+
+### 2.5. Building the AOI, or Area of Interest (`app.R`, lines ~414-586)
+Four AOI sources are supported:
+- region selection (`regions`);
+- district selection (`raions`);
+- hromada selection (`OTG`);
+- a user file (`.kml/.kmz`) or a polygon drawn with the mouse.
+
+Flow:
+1. Any new action clears old layers and points.
+2. Dependent selectors are updated, for example the district list after a region is selected.
+3. The AOI is written into `reaktive_aoi_polygon()`.
+4. `reaktive_bufered_polygon()` is synchronized. Initially, it equals the AOI before buffering.
+5. The data retrieval button is enabled.
+
+Analogy:
+- The AOI works like a search frame in a map search tool: first the user defines the frame, then requests data inside it.
+
+### 2.6. Buffering (`app.R` ~590-609 and `custom_functions.R`)
+- When `buffer_radius` changes, the application calls:
+  - `polygon_bufferisation(sf_input_polygon, radius)`.
+- The function:
+  1. transforms the geometry to the metric CRS `3537`;
+  2. builds a buffer in meters;
+  3. converts the result back to EPSG:4326;
+  4. merges the geometry with `st_union`.
+
+Why this is required:
+- Buffering in degrees in WGS84 is not physically correct for distance-based operations, so a metric projection is necessary.
+
+Example of the key logic with comments:
+```r
+sf_polygon_buffered <- st_transform(sf_input_polygon, CRS_used_in_calculations) %>%  # to meters
+  st_buffer(dist = as.numeric(radius), nQuadSegs = 4) %>%                             # buffer in m
+  st_transform(4326) %>%                                                               # back to lon/lat
+  st_union()                                                                            # single geometry
+```
+
+### 2.7. Retrieving GBIF Data by AOI (`app.R`, lines ~612-747)
+- The `sf_clipped_data` reactive is triggered by the `act_get_gbif_data` button.
+- The source is the FlatGeobuf file `gbif_sf_dataset.fgb`.
+- The code uses `wkt_filter`, which means the spatially filtered subset is read directly:
+
+```r
+read_sf(path_datadump_fgb, wkt_filter = reaktive_bufered_polygon() %>% st_as_text())
+```
+
+Why this is a good approach:
+- The full occurrence dataset is not loaded into memory for every request.
+- The spatial filter is applied during reading, which is usually faster.
+
+After loading:
+- The AOI, buffer, and points are drawn on `map`.
+- The same points are initially shown on `map2`, then replaced by the filtered result.
+- The apply and clear filter buttons are enabled.
+
+### 2.8. Filtering Occurrence Records (`app.R`, lines ~792-885)
+- `sf_filteredData()`:
+  - takes `sf_clipped_data()`;
+  - applies a large OR filter across:
+    - the Red Book of Ukraine (`ЧКУ`);
+    - IUCN;
+    - international lists;
+    - regional lists;
+    - invasiveness;
+  - then applies an AND filter by kingdom (`kingdom_filters`).
+- The result is displayed on `map2` with popups and links.
+
+Pattern:
+- The application uses Shiny's reactive graph: input changes trigger recalculation of dependent nodes.
+- `intern_filt_present` and `region_filt_present` act as masks for active filters by index.
+
+### 2.9. Table and Exports (`app.R`, lines ~888-932)
+- `df_filteredData()` removes geometry with `st_drop_geometry` and keeps the required fields.
+- The Preview tab table is rendered with `DT::renderDataTable`.
+- Export formats:
+  - CSV via `write.csv`;
+  - XLSX via `write_xlsx`.
+- The UI also displays the number of records and the GBIF DOI citation.
+
+### 2.10. Summary Tables and Report (`app.R`, lines ~939-1605 + `templates/report.Rmd`)
+- When `refresh_filters` is clicked, the application builds:
+  - a summary table by category;
+  - a general species table;
+  - separate tables for each agreement or list.
+- Tables and `nrow_*` values are stored in `reactiveVal` objects so they can be used both in the UI and in R Markdown.
+- `downloadReport`:
+  - copies the template and logos to a temporary folder;
+  - runs `rmarkdown::render` in HTML or Word format;
+  - returns the file to the user.
+
+Why this scheme works:
+- R Markdown can access the already calculated reactive data within the same session.
+
+### 2.11. Global Reactive Values (`global_reactive_value.R`)
+- `reaktive_aoi_polygon`, `reaktive_bufered_polygon`, and `df_rare_lists` are initialized.
+- A loop with `assign()` dynamically creates pairs of values:
+  - `tab_filtred_*`;
+  - `nrow_*`.
+
+This reduces duplication when declaring variables, but makes code navigation harder because the names are not visible explicitly in one place.
+
+<a id="sec-3"></a>
+## 3. Key Concepts
+
+### 3.1. Shiny Reactive Architecture
+- `observeEvent` - performs an action when an event occurs, such as a button click or input change.
+- `reactive` - defines a computed value that depends on inputs.
+- `eventReactive` - computes a value only when a specific trigger fires.
+
+In simple terms, this is a dependency graph where nodes are automatically recalculated when their inputs change.
+
+### 3.2. Spatial Processing with `sf`
+- `st_read`, `read_sf` - read spatial data.
+- `st_union`, `st_bbox` - merge geometries and calculate bounding boxes.
+- `st_transform` + `st_buffer` - perform correct buffering in a metric projection.
+
+### 3.3. Patterns
+- Modular configuration: parameters and strings are moved out of `app.R`.
+- Proxy update pattern with `leafletProxy` for fast incremental map updates.
+- Template pattern for reporting with `templates/report.Rmd` and a set of reactive tables.
+
+<a id="sec-4"></a>
+## 4. Potential Issues
+
+### 4.1. Logical and Functional Risks
+- `if(is.null(reaktive_bufered_polygon)){...}` checks the function, not its value (`app.R:618`).
+  It should be `reaktive_bufered_polygon()`.
+- `arrange("kingdom", "class", ...)` sorts by string literals, not by columns (`app.R:891`).
+  It should be `arrange(kingdom, class, family, scientificName)`.
+- `fitBounds` on an empty filter result can produce an invalid bbox (`app.R:860-865`), so the code needs `req(nrow(sf_filteredData()) > 0)` or a fallback.
+- When `clear_filters` is used, almost all lists are set to `NULL` (`app.R:767-790`). The resulting OR filter may reduce the selection to zero records. This may be intentional, but the UX is ambiguous.
+
+### 4.2. Performance
+- The report section contains a lot of duplication, with dozens of similar blocks (`app.R:939-1538`), making maintenance and changes expensive.
+- Frequent debug `print(...)` calls in `observe` (`app.R:1634-1667`) add log noise and can slow the app during frequent reactive events.
+- `base_map(..., basemap='google-terrain')` in `renderPlot` may be heavy and network-bound (`app.R:1549-1551`).
+
+### 4.3. Reliability and Security
+- User-uploaded `.kml/.kmz` files are read without size limits or additional geometry validation (`app.R:496-513`), which can lead to errors or long processing times.
+- `load(...Rdata)` depends on the binary file contents and creates objects as-is (`app.R:51`), which makes the data schema hard to control.
+- Using `rm(list = ls())` at startup and session end (`app.R:10`, `app.R:1630`) can unexpectedly remove objects and makes maintenance harder.
+
+<a id="sec-5"></a>
+## 5. Usage Example
+
+### 5.1. How to Run the Application
+```r
+setwd("gbif_app_v2")
+shiny::runApp("app.R")
+```
+
+### 5.2. Typical User Flow
+1. On the **Map** tab, select a district or hromada, or upload/draw a polygon.
+2. Choose a buffer radius, or set it to `0` for no buffer.
+3. Click **Get GBIF Data**.
+4. On the filters tab, choose criteria and click **Apply Filters**.
+5. Download CSV/XLSX or generate a report on the reports tab.
+
+### 5.3. Example of a Complex Filter, Conceptually
+```r
+# Take data clipped by AOI and apply filters:
+# 1) at least one conservation criterion (OR),
+# 2) then a kingdom constraint (AND).
+sf_filtered <- sf_clipped %>%
+  dplyr::filter(
+    iucnRedListCategory %in% selected_iucn |
+    ЧКУ %in% selected_chku |
+    (selected_berne1 & BernAppendix1 == "yes")
+  ) %>%
+  dplyr::filter(kingdom %in% selected_kingdoms)
+```
+
+<a id="sec-6"></a>
+## 6. Operational Issue on shinyapps.io
+
+The current production version of the application hosted on `shinyapps.io` regularly runs into RAM limits. When several users work at the same time, or when requests cover large territories and return tens of megabytes of point data, memory consumption grows sharply. This causes sessions to terminate unexpectedly and can bring the application down.
+
+### 6.1. How It Appears
+- Out-of-memory errors during query execution.
+- User sessions disconnect while data is being loaded or filtered.
+- The application becomes unstable when several users are active in parallel.
+
+### 6.2. When It Happens Most Often
+- Several users are working at the same time.
+- A large AOI is requested.
+- The resulting subset contains a large volume of point data, usually tens of MB or more.
+
+### 6.3. Impact on Users
+- Loss of progress in the current session.
+- Inability to complete analysis for large territories.
+- Lower trust in service stability during peak load.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Anton Biatov, Yehor Yatsiuk, and Oleh Prylutskyi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # gbif_shiny_onlineviewer
 
-**GBIF Viewer**: an open web-based biodiversity conservation decision-making tool for policy and governance. Спільний проєкт The [Habitat Foundation](https://thehabitatfoundation.org/) та [Української Природоохоронної Групи](https://uncg.org.ua/), за підтримки [NLBIF: The Netherlands Biodiversity Information Facility](https://www.nlbif.nl/), nlbif2022.014
+**GBIF Viewer**: an open web-based biodiversity conservation decision-making tool for policy and governance. Спільний проєкт The [Habitat Foundation](https://thehabitatfoundation.org/) та [NGO “Ukrainian Nature Conservation Group”](https://uncg.org.ua/), за підтримки [NLBIF: The Netherlands Biodiversity Information Facility](https://www.nlbif.nl/), nlbif2022.014
 
 
-The GBIF Viewer consists of 2 components: a data dump creator and a web-viewer. There must be some kind of file storage through which data must be transferred between these components.
+The GBIF Viewer consists of 2 components: a [data dump creator](https://github.com/olehprylutskyi/GBIF_occurence_download) and a [web-viewer](https://github.com/ABiatov/gbif_shiny_onlineviewer). There must be some kind of file storage through which data must be transferred between these components.
 The storage role for the data dump can be a Docker volume or a folder on the host server or cloud storage. This storage must be mounted to the container.
+
+## Documentation
+
+- [Code_Explanation.md](Code_Explanation.md) - code walkthrough for `gbif_app_v2`, including architecture, data flow, risks, and operational notes.
+- [further_improvement.md](further_improvement.md) - improvement, migration, and scaling plan for the application.
 
 
 ## Folders in this repository
@@ -75,5 +80,13 @@ cd deploy_webapp
 
 ```
 
+## License
 
+This repository is released under the [MIT License](LICENSE).
+
+Code authors:
+
+- Anton Biatov ([GitHub](https://github.com/ABiatov))
+- Yehor Yatsiuk ([ResearchGate](https://www.researchgate.net/profile/Yehor-Yatsiuk))
+- Oleh Prylutskyi ([GitHub](https://github.com/olehprylutskyi))
 

--- a/further_improvement.md
+++ b/further_improvement.md
@@ -1,0 +1,448 @@
+# Further Improvement Plan for `gbif_app_v2`
+
+This document contains the development, migration, and scaling proposals extracted from `Code_Explanation.md`.
+
+## Table of Contents
+1. [1. Quick Improvements for the Current Code](#sec-1)
+2. [2. Goals & Scope](#sec-2)
+3. [3. Stakeholders & Users](#sec-3)
+4. [4. User Journeys](#sec-4)
+5. [5. Current Architecture (As-Is)](#sec-5)
+6. [6. Module Responsibility Map](#sec-6)
+7. [7. Data Contracts](#sec-7)
+8. [8. Dependency Inventory](#sec-8)
+9. [9. Non-Functional Requirements (NFR)](#sec-9)
+10. [10. Error Handling & Failure Modes](#sec-10)
+11. [11. Security & Privacy](#sec-11)
+12. [12. Observability](#sec-12)
+13. [13. Test Strategy](#sec-13)
+14. [14. Tech Debt Register](#sec-14)
+15. [15. ADR (Architecture Decision Record)](#sec-15)
+16. [16. Target Stack Options for Migration](#sec-16)
+17. [17. Concept Mapping (Shiny -> New Architecture)](#sec-17)
+18. [18. API Boundary Plan (To-Be)](#sec-18)
+19. [19. State Management Plan (To-Be)](#sec-19)
+20. [20. Data Pipeline Plan (To-Be)](#sec-20)
+21. [21. Backward Compatibility & Parity Checklist](#sec-21)
+22. [22. Migration Strategy](#sec-22)
+23. [23. Roadmap (Draft)](#sec-23)
+24. [24. Open Questions for AI Brainstorming](#sec-24)
+25. [25. Load Profile and Scaling Plan (30-50 Concurrent Users)](#sec-25)
+
+<a id="sec-1"></a>
+## 1. Quick Improvements for the Current Code
+
+### 1.1. Possible Improvements
+- Move repeated report blocks into a generator function driven by configuration, for example a mapping of field, label, and reactive key.
+- Replace index-based filtering logic such as `intern_filt_present()[N]` with a `name -> column` dictionary to remove position-based fragility.
+- Add `req(...)` and `validate(need(...))` before critical calculations such as `bbox`, `renderPlot`, and file reading.
+- Move geospatial operations into a separate `R/geo.R` module and report aggregates into `R/report.R`.
+- Add tests:
+  - a unit test for `polygon_bufferisation`;
+  - filter tests for OR/AND logic correctness;
+  - an integration test for report generation.
+
+<a id="sec-2"></a>
+## 2. Goals & Scope
+
+### 2.1. Goals of the Current Version (As-Is)
+- Provide fast web access to GBIF occurrence records within a selected area of interest.
+- Support filtering by biodiversity conservation criteria, including national and international lists.
+- Support exporting results to table formats and reports.
+
+### 2.2. Goals of the Next Version (To-Be)
+- Improve maintainability and reduce code duplication.
+- Improve resilience to invalid input data and empty results.
+- Prepare the architecture for migration to another language or stack without losing functionality.
+
+### 2.3. Out of Scope
+- A full redesign of the domain model, such as taxonomy or classification, without a separate project.
+- Manual editing of the source GBIF dataset from the application interface.
+
+<a id="sec-3"></a>
+## 3. Stakeholders & Users
+- Primary users: biodiversity specialists, analysts, conservation NGOs, and government or governance bodies.
+- Technical users: developers and analysts who maintain the code and data.
+- Business interest: fast and reproducible occurrence selection for decision-making and reporting.
+
+<a id="sec-4"></a>
+## 4. User Journeys
+
+### 4.1. Main Scenario
+1. The user selects an AOI.
+2. The user adds a buffer if needed.
+3. The user requests a GBIF subset.
+4. The user applies filters.
+5. The user reviews the map and table.
+6. The user exports CSV/XLSX/HTML/DOCX.
+
+### 4.2. Alternative Scenarios
+- AOI provided through a `.kml/.kmz` upload.
+- AOI created by drawing and editing on the map.
+- Quick filter reset and repeated analysis.
+
+### 4.3. Failure Scenarios
+- Invalid boundary file.
+- Empty result after filtering.
+- Error during report generation.
+
+<a id="sec-5"></a>
+## 5. Current Architecture (As-Is)
+
+### 5.1. Component Context Diagram
+- UI: Shiny tabs, inputs, and outputs.
+- Reactive state: `reactiveVal`, `reactive`, and `eventReactive`.
+- Spatial engine: `sf`, `leaflet`, and `leafletProxy`.
+- Data layer: FlatGeobuf plus RData metadata.
+- Report engine: `rmarkdown` and `report.Rmd`.
+
+### 5.2. Data Flow
+1. AOI selection or drawing -> `reaktive_aoi_polygon`.
+2. Buffering -> `reaktive_bufered_polygon`.
+3. Spatial query with `wkt_filter` -> `sf_clipped_data`.
+4. Business filtering -> `sf_filteredData`.
+5. Display, export, and report generation.
+
+### 5.3. Architectural Constraints
+- Reactive logic and business logic are heavily mixed in a single `app.R`.
+- Report table blocks contain a large amount of duplication.
+- The domain layer is weakly isolated from the UI layer.
+
+<a id="sec-6"></a>
+## 6. Module Responsibility Map
+
+| Module | Responsibility | Risks |
+|---|---|---|
+| `app.R` | UI, reactivity, filters, maps, exports, reports | Overloaded, duplicated logic |
+| `config.R` | Constants, field/filter lists, styles | Fragile when column names change |
+| `custom_functions.R` | Geospatial helper functions | Input validation is needed |
+| `global_reactive_value.R` | Reactive containers | Dynamic names make refactoring harder |
+| `localization_*.R` | UI/report text | Localization files may drift apart |
+| `templates/report.Rmd` | Report structure | Duplicated conditions and tables |
+
+<a id="sec-7"></a>
+## 7. Data Contracts
+
+### 7.1. Input Contracts
+- AOI geometry:
+  - Format: polygon or multipolygon in WGS84 CRS (EPSG:4326).
+  - Sources: `adm_*`, `.kml/.kmz`, draw toolbar.
+- GBIF dataset fields, critical:
+  - Geospatial: `Latitude`, `Longitude`, `geometry`.
+  - Taxonomy: `kingdom`, `class`, `family`, `scientificName`, `nameUk`.
+  - Filter attributes: `ЧКУ`, `iucnRedListCategory`, `BernAppendix*`, `ЧС_*`, `Invasive`.
+
+### 7.2. Output Contracts
+- Map: occurrence points plus AOI and buffer.
+- Table exports: CSV/XLSX with columns from `colnames_set1/2`.
+- Report: HTML/DOCX based on `templates/report.Rmd`.
+
+### 7.3. Invariants
+- The buffer is calculated in meters after CRS transformation.
+- Every visualization should handle an empty dataset without breaking the UI.
+- Column names in `config.R` must match the actual dataset schema.
+
+<a id="sec-8"></a>
+## 8. Dependency Inventory
+
+### 8.1. Main Packages
+- UI/reactivity: `shiny`, `shinyWidgets`, `shinyjs`, `DT`.
+- Geospatial: `sf`, `sp`, `leaflet`, `leaflet.extras`, `leaflet.esri`, `leafem`.
+- Data/export: `dplyr`, `openxlsx2`, `data.table`.
+- Reports: `rmarkdown`, `knitr`, `markdown`.
+
+### 8.2. External Dependencies
+- Basemap services: Visicom, ESRI, terrain basemap.
+- Local shapefiles and datasets in `gbif_data/`.
+
+<a id="sec-9"></a>
+## 9. Non-Functional Requirements (NFR)
+
+### 9.1. Performance
+- Expected response time for spatial query and filtering.
+- Limits on uploaded file size and point count.
+
+### 9.2. Reliability
+- Correct behavior with empty selections, broken geometries, and missing fields.
+- Predictable recovery after report errors.
+
+### 9.3. Scalability
+- Ability to work with larger datasets without loading everything into RAM.
+- Ability to split the application into a backend API and frontend.
+
+### 9.4. UX
+- Clear error and loading-status messages.
+- Stable map interactivity on low-powered machines.
+
+<a id="sec-10"></a>
+## 10. Error Handling & Failure Modes
+
+| Scenario | Current Behavior | Desired Behavior |
+|---|---|---|
+| Empty `sf_filteredData` | Errors may occur in `fitBounds`/plot | `validate(need(...))`, fallback bbox, informative text |
+| Invalid `.kml/.kmz` | Read error | try-catch plus user-facing text |
+| Required dataset column is missing | dplyr/select error | Startup schema check plus fail-fast behavior |
+| Report render failure | Error during download | try-catch plus logs and a user-facing message |
+
+<a id="sec-11"></a>
+## 11. Security & Privacy
+- Validate MIME type, extension, and size for uploaded files.
+- Validate AOI geometry with `st_is_valid` and use `st_make_valid` if needed.
+- Record basemap and GBIF licenses and attribution in the report.
+- Avoid executing or trusting unchecked binary inputs without schema validation.
+
+<a id="sec-12"></a>
+## 12. Observability
+
+### 12.1. What to Log
+- Spatial query execution time.
+- Filtering and report render time.
+- Selection size before and after filters.
+- Geometry parsing and report generation errors.
+
+### 12.2. Metrics
+- `query_duration_ms`
+- `filtered_rows_count`
+- `report_generation_ms`
+- `error_rate_by_stage`
+
+### 12.3. Minimum Alerts
+- Sharp increase in render/download errors.
+- Abnormally long response time.
+
+<a id="sec-13"></a>
+## 13. Test Strategy
+
+### 13.1. Unit Tests
+- `polygon_bufferisation`: CRS correctness, geometry type, area greater than zero.
+- `leaf_draw_sf_polyg`: coordinate conversion into a valid polygon.
+- Filtering functions or blocks: correct OR/AND logic.
+
+### 13.2. Integration Tests
+- Scenario: AOI -> buffer -> get data -> filters -> export.
+- Report generation for non-empty and empty datasets.
+
+### 13.3. Contract Tests
+- Input data schema validation, including required columns and types.
+
+<a id="sec-14"></a>
+## 14. Tech Debt Register
+
+| Debt | Impact | Priority | Candidate Fix |
+|---|---|---|---|
+| Duplicated report blocks | High cost of change | High | Config-driven generator |
+| Index-based filter logic | Risk of errors when order changes | High | `filter_key -> column` mapping |
+| Mixed UI and domain logic | Difficult refactoring | High | Extract a service layer |
+| Debug `print` calls in production code | Noise and overhead | Medium | Structured logger |
+
+<a id="sec-15"></a>
+## 15. ADR (Architecture Decision Record)
+
+### ADR-001: Spatial Query via FlatGeobuf + `wkt_filter`
+- Status: accepted in the current version.
+- Reason: lower memory usage and faster selection.
+- Trade-off: dependency on the format and on valid WKT AOI input.
+
+### ADR-002: Reactive Monolithic Shiny Architecture
+- Status: historically accepted.
+- Reason: fast start and minimal time-to-market.
+- Trade-off: limited modularity and difficult scaling.
+
+<a id="sec-16"></a>
+## 16. Target Stack Options for Migration
+
+### Option A: Python + FastAPI + React + deck.gl/MapLibre
+- Pros: strong backend ecosystem, flexible API, scalability.
+- Cons: more infrastructure work.
+
+### Option B: TypeScript Full Stack (NestJS + React)
+- Pros: one language, good end-to-end typing.
+- Cons: the geospatial pipeline may require more manual setup.
+
+### Option C: R Backend API + Separate Frontend
+- Pros: smoother migration, preserves part of the R expertise.
+- Cons: some R/Shiny limitations may remain.
+
+<a id="sec-17"></a>
+## 17. Concept Mapping (Shiny -> New Architecture)
+
+| Shiny Concept | Target Equivalent |
+|---|---|
+| `reactiveVal` | Store/State (Redux/Zustand/Signals) + server state cache |
+| `observeEvent` | Event handlers + command bus/use-case services |
+| `eventReactive` | Explicit query trigger (API call / mutation) |
+| `render*` | Component rendering + state selectors |
+| `leafletProxy` | Imperative map controller/ref |
+
+<a id="sec-18"></a>
+## 18. API Boundary Plan (To-Be)
+- `POST /aoi/query` - spatial query by AOI plus buffer.
+- `POST /filters/apply` - apply filters and return a table or GeoJSON.
+- `GET /exports/csv|xlsx` - exports.
+- `POST /reports` - report generation.
+
+Minimum request contract:
+```json
+{
+  "aoi_wkt": "POLYGON((...))",
+  "buffer_m": 5000,
+  "filters": {
+    "iucn": ["CR", "EN"],
+    "international": ["Bern Appendix 1"],
+    "kingdom": ["Animalia", "Plantae"],
+    "invasive": false
+  }
+}
+```
+
+<a id="sec-19"></a>
+## 19. State Management Plan (To-Be)
+- Split state into:
+  - `map_state` (AOI, bbox, buffer),
+  - `query_state` (request status, timing, errors),
+  - `filter_state`,
+  - `result_state` (table, geo-features, summary),
+  - `report_state`.
+- Introduce explicit statuses: `idle | loading | success | empty | error`.
+
+<a id="sec-20"></a>
+## 20. Data Pipeline Plan (To-Be)
+1. Validate AOI.
+2. Normalize CRS.
+3. Run an indexed spatial query.
+4. Apply business filters.
+5. Build report aggregations.
+6. Cache frequently repeated requests.
+
+<a id="sec-21"></a>
+## 21. Backward Compatibility & Parity Checklist
+
+### 21.1. Compatibility
+- Keep the same AOI input formats (`.kml/.kmz`, draw).
+- Keep the key export formats: CSV/XLSX/DOCX/HTML.
+- Keep filtering rules and the default column set.
+
+### 21.2. Feature Parity
+- [ ] AOI selection by `adm_1/2/3`.
+- [ ] Custom polygon.
+- [ ] Buffer in meters.
+- [ ] Spatial query against the dataset.
+- [ ] Filters by `ЧКУ`, IUCN, conventions, and regional lists.
+- [ ] Map with popups and links.
+- [ ] CSV/XLSX export.
+- [ ] Report generation.
+
+<a id="sec-22"></a>
+## 22. Migration Strategy
+
+### 22.1. Stage 1 - Stabilize As-Is
+- Fix critical bugs: `is.null`, `arrange`, and empty bbox handling.
+- Add contract checks for the data schema.
+- Add a minimal test suite.
+
+### 22.2. Stage 2 - Extract Core
+- Move geospatial and filtering logic into an independent service layer.
+- Prepare API contracts and end-to-end parity tests.
+
+### 22.3. Stage 3 - Parallel Run
+- Run the new service next to the old one.
+- Compare results for identical inputs.
+- Keep a discrepancy log.
+
+### 22.4. Stage 4 - Cutover
+- Switch the UI to the new backend.
+- Keep fallback to the old version for a limited period.
+
+<a id="sec-23"></a>
+## 23. Roadmap (Draft)
+
+### Milestone M1 (2-4 Weeks)
+- Critical bug fixes and stabilization.
+- Logs, metrics, and basic tests.
+
+### Milestone M2 (4-8 Weeks)
+- Service layer and API prototype.
+- Refactoring of report aggregates.
+
+### Milestone M3 (8-12 Weeks)
+- New UI/architecture in parallel-run mode.
+- Parity and performance verification.
+
+### Milestone M4 (12+ Weeks)
+- Production cutover.
+- Post-migration optimization.
+
+<a id="sec-24"></a>
+## 24. Open Questions for AI Brainstorming
+- What response-time SLA is acceptable for spatial queries?
+- What maximum AOI or file size should be supported?
+- Is a multi-user mode with state isolation and job queues needed?
+- Which is more important: development speed or long-term scalability?
+- What dataset versioning and report reproducibility strategy is needed?
+- Is offline mode or basemap caching required?
+- What level of backward compatibility is mandatory for external users?
+
+<a id="sec-25"></a>
+## 25. Load Profile and Scaling Plan (30-50 Concurrent Users)
+
+### 25.1. Target Load Profile
+- Concurrent active users: `30-50`.
+- Load type: interactive spatial queries with large AOI polygons.
+- Result size: up to `10-50+ MB` of points and attributes per request.
+- Peak mode: several heavy requests run at the same time, including report generation.
+
+### 25.2. SLO/SLA for VNext
+- `P50` for a typical request: up to `2-4 sec`.
+- `P95` for a heavy request: up to `10-20 sec`, or move it to async mode.
+- API errors (`5xx`) under load: no more than `1%`.
+- Large report generation time: up to `30-90 sec` as a background job.
+
+### 25.3. Query Classes and Execution Modes
+- `Small/Medium query`, with results up to about 10 MB: synchronous response.
+- `Large query`, with results above about 10 MB: asynchronous queueing; the user receives a `job_id`.
+- `Very large export/report`: async only, with notification when the file is ready.
+
+### 25.4. Architectural Measures for Resilience
+- Introduce a background task queue for heavy operations such as `query`, `report`, and `export`.
+- Limit heavy-task parallelism in the worker pool, for example `2-4` tasks per instance.
+- Add backpressure: limits on active heavy jobs per user and per system.
+- Separate API instances for fast responses from worker instances for heavy tasks.
+- Support horizontal scaling of the stateless layer through a load balancer.
+
+### 25.5. Working with Large Geospatial Data
+- Use a spatial index and bbox pre-filtering before exact intersections.
+- Store and read data in a format optimized for spatial scans, such as FlatGeobuf, GeoParquet, or PostGIS.
+- Return geospatial data in compressed form with `gzip`/`br`, and support chunked or streaming responses.
+- Add a server-side limit on the maximum number of points shown on the interactive map and use progressive aggregation.
+- For large map volumes, degrade detail gracefully with clustering, tiling, or sampling.
+
+### 25.6. Limits and Protective Mechanisms
+- Limit uploaded AOI file size and geometry complexity, including vertex count.
+- Set per-stage timeouts for spatial query, filtering, export, and report rendering.
+- Use retry policies only for idempotent steps.
+- Apply rate limiting per user/IP for heavy endpoints.
+- Add circuit breakers for external dependencies, such as basemap or remote services.
+
+### 25.7. Caching
+- Cache repeated results by key: `hash(AOI + buffer + filters + dataset_version)`.
+- Use separate TTL values for interactive previews and exports.
+- Cache intermediate report aggregations.
+- Invalidate cache when the dataset version changes.
+
+### 25.8. Observability Under Load
+- Metrics: `concurrent_users`, `queue_depth`, `job_wait_ms`, `job_run_ms`, `p95_latency`, `memory_rss`, `cpu`, `error_rate`.
+- Logs: dimensions such as `query_class`, `aoi_area`, `result_size_mb`, and `rows_count`.
+- Alerts: queue growth, rising `p95`, OOM events, and increasing timeout share.
+
+### 25.9. Load Testing Plan, Required
+1. Prepare three scenario sets: `small`, `medium`, and `large` AOI.
+2. Run tests with `30`, `40`, and `50` concurrent users.
+3. Run a separate stress test for simultaneous large requests with `10-50+ MB` responses.
+4. Run a soak test for `1-2 hours` to check for memory leaks and degradation.
+5. Record pass thresholds for SLO and resilience.
+
+### 25.10. Acceptance Criteria for Performance
+- The system stably serves `30-50` concurrent users without critical UX degradation.
+- Heavy requests do not block interactive operations for other users.
+- Memory and queue size do not grow uncontrollably under sustained load.
+- All long-running tasks are executed through an observable async pipeline with clear user-facing status.

--- a/gbif_app_v2/gbif_data/get_datadump.R
+++ b/gbif_app_v2/gbif_data/get_datadump.R
@@ -7,16 +7,24 @@ library(sf)
 # For example
 # setwd("C:/Users/admin/Documents/GitHub/gbif_shiny_onlineviewer/gbif_app_v2/gbif_data/")
 
-link_gbif_sf_dataset <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/main/outputs/gbif_sf_dataset.Rdata"
+# link_gbif_sf_dataset <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/main/outputs/gbif_sf_dataset.Rdata"
+# link_metadata <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/main/outputs/metadata.Rdata"
+# Ссылки ^поменялись, нужно вручную скачивать, или обновить ссылки.
 
-link_metadata <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/main/outputs/metadata.Rdata"
+link_gbif_sf_dataset <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/refs/heads/main/outputs/gbif_sf_dataset.Rdata"
+link_metadata <- "https://github.com/olehprylutskyi/GBIF_occurence_download/raw/refs/heads/main/outputs/metadata.Rdata"
 
-file_name_gbif_sf_dataset <- "gbif_sf_dataset.Rdata"
+# For run in RStudio
+# file_name_gbif_sf_dataset <- "gbif_sf_dataset.Rdata"
+# file_name_metadata <- "metadata.Rdata"
+# output_fgb_file <- "gbif_sf_dataset.fgb"
 
-file_name_metadata <- "metadata.Rdata"
+# For run in VS Code 
+file_name_gbif_sf_dataset <- "gbif_app_v2/gbif_data/gbif_sf_dataset.Rdata"
+file_name_metadata <- "gbif_app_v2/gbif_data/metadata.Rdata"
+output_fgb_file <- "gbif_app_v2/gbif_data/gbif_sf_dataset.fgb"
 
 download.file(link_metadata, file_name_metadata, mode = "wb")
-
 download.file(link_gbif_sf_dataset, file_name_gbif_sf_dataset, mode = "wb")
 
 load(file = file_name_metadata)
@@ -24,7 +32,7 @@ load(file = file_name_metadata)
 load(file = file_name_gbif_sf_dataset)
 
 write_sf(gbif_sf_dataset, 
-         dsn="gbif_sf_dataset.fgb",
+         dsn=output_fgb_file,
          driver="FlatGeobuf",
          delete_dsn= TRUE)
 

--- a/name_lookup/README.md
+++ b/name_lookup/README.md
@@ -1,4 +1,6 @@
 # GBIF_occurence_download
+The `name_lookup/` directory is a copy of the [olehprylutskyi/GBIF_occurence_download](https://github.com/olehprylutskyi/GBIF_occurence_download) repository.
+
 Pipeline for download occurrences for a series of scientific names, including taxonomic matching and problem resolving.
 
 ![Workflow](https://github.com/olehprylutskyi/GBIF_occurence_download/blob/main/gbif_occ_downloader_workflow.png)


### PR DESCRIPTION
Add English documentation for gbif_app_v2 architecture, risks, and improvement plan. Update the main README with documentation links, project source links, license/authors section, and clarify that name_lookup is copied from the upstream GBIF_occurence_download repository. Update the GBIF data dump download script and refresh local dataset metadata/files.